### PR TITLE
Add Serializable to RingBuffer type, bump Clojure to 1.6.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,4 +3,4 @@
   :url "http://github.com/amalloy/ring-buffer"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/src/amalloy/ring_buffer.clj
+++ b/src/amalloy/ring_buffer.clj
@@ -1,6 +1,6 @@
 (ns amalloy.ring-buffer
   (:import (clojure.lang Counted Sequential IPersistentCollection IPersistentStack Reversible IObj)
-           (java.io Writer)))
+           (java.io Writer Serializable)))
 
 ;; If one of our numbers gets over 2 billion, the user's ring buffer is way too large!
 ;; and count is defined to return an int anyway, so we can't make it work regardless.
@@ -9,6 +9,8 @@
 (set! *unchecked-math* true)
 
 (deftype RingBuffer [^long start ^long len buf meta]
+  Serializable
+  
   Counted
   (count [this] len)
 

--- a/test/amalloy/ring_buffer_test.clj
+++ b/test/amalloy/ring_buffer_test.clj
@@ -1,6 +1,12 @@
 (ns amalloy.ring-buffer-test
   (:use clojure.test
-        amalloy.ring-buffer))
+        amalloy.ring-buffer)
+  (:import [java.io
+            ByteArrayOutputStream
+            ByteArrayInputStream
+            ObjectOutputStream
+            ObjectInputStream
+            ]))
 
 (deftest features
   (let [b (ring-buffer 3)]
@@ -8,3 +14,17 @@
     (is (= '(c d e) (into b '(a b c d e))))
     (is (= '(d e) (pop (into b '(a b c d e)))))
     (is (= 'c (peek (into b '(a b c d e)))))))
+
+(deftest test-serializable
+  (let [^ByteArrayOutputStream baos (ByteArrayOutputStream.)
+        ^ObjectOutputStream ois (ObjectOutputStream. baos)
+        rb (-> (ring-buffer 5)
+               (conj 1 2 3 4 5)
+               (conj "one" "two" "three"))]
+    (.writeObject ois rb)
+    (let [^ObjectInputStream ois (-> baos
+                                     .toByteArray
+                                     ByteArrayInputStream.
+                                     ObjectInputStream.)
+          rb2 (.readObject ois)]
+      (is (= rb rb2)))))


### PR DESCRIPTION
Hi!  Handy little data structure!

I added Serializable since I need to be able to serialize RingBuffers over a network channel.

I'm also probably going to add some java.util.Collection or at least Iterable interfaces to it to facilitate interop with Java code.  Let me know if you're interested in pulling these changes.

--mike
