### PR TITLE
Add support for rseq

### DIFF
--- a/src/amalloy/ring_buffer.clj
+++ b/src/amalloy/ring_buffer.clj
@@ -55,6 +55,11 @@
     (seq (for [i (range len)]
            (nth buf (rem (+ start i) (count buf))))))
 
+  Reversible
+  (rseq [this]
+    (seq (for [i (range (- len 1) -1 -1)]
+           (nth buf (rem (+ start i) (count buf))))))
+
   Collection
   (iterator [this]
     (.iterator ^Iterable (sequence this)))

--- a/src/amalloy/ring_buffer.cljs
+++ b/src/amalloy/ring_buffer.cljs
@@ -49,6 +49,11 @@
        (seq (for [i (range len)]
               (nth buf (rem (+ start i) (count buf))))))
 
+  IReversible
+  (-rseq [this]
+        (seq (for [i (range (- len 1) -1 -1)]
+               (nth buf (rem (+ start i) (count buf))))))
+
   IPrintWithWriter
   (-pr-writer [b w opts]
               (-write w "(")

--- a/test/amalloy/ring_buffer_test.cljc
+++ b/test/amalloy/ring_buffer_test.cljc
@@ -47,4 +47,5 @@
     (is (= 4 (count rb)))
     (is (empty? (ring-buffer 10)))
     (is (not (empty? rb)))
+    (is (= (reverse expected) (rseq rb)))
     (is (= expected (seq (to-array rb))))))


### PR DESCRIPTION
Uses the same logic as `seq` to implement `Reversible` and `IReversible`.